### PR TITLE
Joseph 404 home ticket

### DIFF
--- a/src/app/(frontend)/home/_components/template.tsx
+++ b/src/app/(frontend)/home/_components/template.tsx
@@ -1,0 +1,9 @@
+const Template = () => {
+  return (
+    <div>
+      <a>This is a template component</a>
+    </div>
+  )
+}
+
+export default Template

--- a/src/app/(frontend)/home/page.tsx
+++ b/src/app/(frontend)/home/page.tsx
@@ -1,0 +1,4 @@
+import Template from './_components/template'
+export default function Page() {
+  return <Template />
+}

--- a/src/app/(frontend)/styles.css
+++ b/src/app/(frontend)/styles.css
@@ -1,3 +1,4 @@
+@import "tailwindcss";
 :root {
   --font-mono: 'Roboto Mono', monospace;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,9 @@
+// this is purely for "not-found.tsx" functionality and aims to not affect any layouts stacked ontop of it
+import './(frontend)/styles.css'
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link'
+
+export default function notFound() {
+  return (
+    <div className="flex flex-col justify-center items-center min-h-screen bg-gray-800 text-white">
+      <h1 className="text-4xl font-bold mb-4">404 - Page Not Found</h1>
+
+      <div className="flex space-x-6">
+        <Link href="/home" className="hover:underline">
+          Go to Home
+        </Link>
+        <Link href="/" className="hover:underline">
+          About Us
+        </Link>
+        <Link href="/" className="hover:underline">
+          Contact
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -2,8 +2,8 @@ import Link from 'next/link'
 
 export default function notFound() {
   return (
-    <div className="flex flex-col justify-center items-center min-h-screen bg-gray-800 text-white">
-      <h1 className="text-4xl font-bold mb-4">404 - Page Not Found</h1>
+    <div className="flex flex-col justify-center items-center min-h-screen bg-gray-800">
+      <h1>404 - Page Not Found</h1>
 
       <div className="flex space-x-6">
         <Link href="/home" className="hover:underline">

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -54,6 +54,7 @@ export type SupportedTimezones =
   | 'Asia/Singapore'
   | 'Asia/Tokyo'
   | 'Asia/Seoul'
+  | 'Australia/Brisbane'
   | 'Australia/Sydney'
   | 'Pacific/Guam'
   | 'Pacific/Noumea'


### PR DESCRIPTION
# Addition of not-found.tsx and template of Home route

I have added a not-found.tsx to the root routing directory (app), it is required to be in this location for nextjs to recognise it. Subsequently I have added a layout.tsx to the same directory location, as this is also required for nextjs to display not-found.tsx. 

This layout.tsx visually does nothing to the (frontend) or any other subsequent route groups. However it should be noted that all subsequent or child layouts are "stacked" ontop of this one. The not-found.tsx also uses styles.css from the (frontend) directory

I have also added a template for the Home route for whenever this needs to be implemented. I used this for testing purposes and works fluently.

I have also added ' @import "tailwindcss"; ' to (frontend)/styles.css because isn't this supposed to be here. I might be tripping. Or do we need to use the globals.css 

# How to review

Decide whether or not we need the template for the home route. I think it may be useful in the future to make things work faster.  Check whether or not I have implemented the not-found.tsx file. I tried putting it in deeper directories but nextjs only recognised it in the root routing directory, app.
  