### PR TITLE
Make sponsors component work on mobile

### DIFF
--- a/src/app/(frontend)/_components/SponsorBubbles.tsx
+++ b/src/app/(frontend)/_components/SponsorBubbles.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Image from 'next/image'
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { SponsorParsed } from '@/types/parsers/parseSponsors'
 
 export interface SponsorProps {
@@ -10,6 +10,21 @@ export interface SponsorProps {
 
 export default function SponsorBubbles({ sponsors }: SponsorProps) {
   const containerRef = useRef<HTMLDivElement>(null)
+  const [baseSize, setBaseSize] = useState(60)
+
+  useEffect(() => {
+    function handleResize() {
+      if (window.innerWidth < 1024) {
+        setBaseSize(60)
+      } else {
+        setBaseSize(90)
+      }
+    }
+
+    handleResize()
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [])
 
   useEffect(() => {
     // Import Packery client side as needs client functionality. As any as idk how to deal with TypeScript error as Packery wasn't made for TypeScript
@@ -30,12 +45,12 @@ export default function SponsorBubbles({ sponsors }: SponsorProps) {
       .catch((error) => {
         console.error('Failed to load Packery:', error)
       })
-  }, [])
+  }, [baseSize])
 
   return (
     <div className="relative h-[24rem] inline-block ml-4 select-none" ref={containerRef}>
       {sponsors.map((sponsor) => {
-        const size = 90 * sponsor.importance
+        const size = baseSize * sponsor.importance
 
         return (
           <div
@@ -48,7 +63,7 @@ export default function SponsorBubbles({ sponsors }: SponsorProps) {
               height={size}
               width={size}
               alt={sponsor.logo.alt || 'Brand logo'}
-              className="select-none scale-105"
+              className="scale-105 select-none"
             />
           </div>
         )

--- a/src/app/(frontend)/_components/Sponsors.tsx
+++ b/src/app/(frontend)/_components/Sponsors.tsx
@@ -10,7 +10,7 @@ export default async function Sponsors() {
   const sponsors = parseSponsors(await getSponsors())
 
   return (
-    <div className="text-primary-white py-12">
+    <div className="py-12 text-primary-white">
       <div className="flex flex-col items-center gap-5 mb-12 ">
         <div className="relative">
           <Link
@@ -19,7 +19,7 @@ export default async function Sponsors() {
           >
             Our Sponsors
           </Link>
-          <div className="absolute flex items-center right-[-16.25rem] top-[-2.2rem] gap-1.5">
+          <div className="absolute items-center right-[-16.25rem] top-[-2.2rem] gap-1.5 hidden lg:flex">
             <Image
               width={90}
               height={90}
@@ -28,11 +28,11 @@ export default async function Sponsors() {
               unoptimized={true}
               className=""
             />
-            <p className="font-super-jellyfish translate-y-[-0.2rem] text-[1rem]">CLICK FOR MORE DETAILS!</p>
+            <p className="font-super-jellyfish translate-y-[-0.2rem]">CLICK FOR MORE DETAILS!</p>
           </div>
         </div>
 
-        <p className="w-[32rem] text-center text-xl/tight font-smeltex-medium tracking-[0.15em]">
+        <p className="w-[80%] text-center text-base/tight font-smeltex-medium tracking-[0.15em] lg:text-lg/tight lg:w-[28.5rem]">
           Enjoy discounts? As uni students we understand, that's why we've sponsored up for you.
           Take a look at ESA's sponsors!
         </p>


### PR DESCRIPTION
# Description
- Improves the responsiveness of the sponsors component. On smaller screens:
  - Made "Click here for more details" disappear 
  - Sponsor bubble sizes reduced to base of 60px from 90px. Point for this is not at tailwind lg breakpoint, happens at a smaller screen size as have to use Javascript to do this
  - Textbox starting with "Enjoy Discounts?..." changes to 80% width from 28.5rem and text decreasing by 1 tailwind increment (lg -> base)

# How To Review
Look at homepage and make sure stuff mentioned above happens

# Improvements
Can look into making the breakpoint for sponsor bubble size changing to match when other stuff changes if needed