### PR TITLE
Make WhoAreWe mobile responsive

### DIFF
--- a/src/app/(frontend)/_components/WhoAreWe.tsx
+++ b/src/app/(frontend)/_components/WhoAreWe.tsx
@@ -21,7 +21,7 @@ export default function WhoAreWe() {
           alt="top left frame"
           width={60}
           height={60}
-          className="absolute -bottom-9 left-145"
+          className="absolute -bottom-10 -right-2 w-[12%] md:w-[7.5%]"
         />
 
         {/* top left frame */}
@@ -30,57 +30,56 @@ export default function WhoAreWe() {
           alt="bottom right frame"
           width={60}
           height={60}
-          className="absolute -top-9 -left-6 scale-x-[-1] scale-y-[-1]"
+          className="absolute -top-5 -left-9 scale-x-[-1] scale-y-[-1] w-[12%] md:w-[7.5%] -rotate-18"
         />
 
         {/* main box component */}
-        <div className="flex h-88 w-150 rounded-[5em] bg-[#ebe9e6]">
+        <div className="flex items-center justify-center gap-11 py-9 px-10 rounded-[5em] bg-[#ebe9e6]">
           {/* background */}
-          <div className="absolute inset-0 bg-[url('/assets/liquid_marbling_background.png')] bg-cover bg-center opacity-9 w-150 rounded-[5em]" />
+          <div className="absolute inset-0 bg-[url('/assets/liquid_marbling_background.png')] bg-cover bg-center opacity-7 rounded-[5em]" />
 
-          {/* foreground */}
-          <div className="relative flex flex-col items-center">
-            {/* team photo */}
-            <div className="relative left-8 top-8">
-              {/* {!isLoaded ? <div className="text-xs text-black">loading...</div> : null} */}
+          {/* Who are we image */}
+          <div className="relative items-center hidden md:flex">
+            <Image
+              // ref={imgRef}
+              src="/assets/team_photo.png"
+              alt="team photo"
+              width={320}
+              height={320}
+              // onLoad={() => setIsLoaded(true)}
+            />
+          </div>
+
+          {/* Right side text */}
+          <div className="z-10 flex flex-col items-center gap-4">
+            <div className="relative">
+              {/* title */}
+              <div className="text-center text-white bg-[#871F1B] px-4 py-1.5 rounded-xl text-2xl font-reservoir-grunge">
+                Who are we?
+              </div>
+              {/* arrow */}
               <Image
-                // ref={imgRef}
-                src="/assets/team_photo.png"
-                alt="team photo"
-                width={220}
-                height={220}
-                // onLoad={() => setIsLoaded(true)}
-                // className={`${isLoaded ? 'block' : 'hidden'}`}
+                src="/assets/arrow.png"
+                alt="arrow"
+                width={105}
+                height={105}
+                className="absolute top-[2rem] left-[-6.2rem] hidden md:block w-[33%]"
               />
             </div>
 
-            {/* arrow */}
-            <Image
-              src="/assets/arrow.png"
-              alt="arrow"
-              width={85}
-              height={85}
-              className="relative left-40 bottom-50"
-            />
-
-            {/* title */}
-            <div className="relative left-75 bottom-75 w-40 h-10 rounded-lg bg-[#871F1B]">
-              <div className="text-center text-2xl text-white">Who are we?</div>
-            </div>
-
             {/* description */}
-            <div className="relative left-75 bottom-70 w-43 text-sm text-black text-center font-medium">
+            <p className="w-56 mb-4 font-medium text-center text-black text-base/tight">
               ESA Social Club is your go-to community for fun, connection, and a little friendly
               competition.
-            </div>
-            <div className="relative left-75 bottom-65 w-60 text-black text-xs">
+            </p>
+            <p className="self-start text-sm tracking-[0.15em] text-black w-86">
               Whether you're here to smash it at sports day, chill at pool night, or game it out at
               arcade night — we've got you.
-            </div>
-            <div className="relative left-75 bottom-60 w-60 text-black text-xs">
+            </p>
+            <p className="self-start text-sm tracking-[0.15em] text-black w-88">
               ESA firmly believes that university life is not just about academic studies...but it's
               also about having fun, and meeting new friends!
-            </div>
+            </p>
           </div>
         </div>
       </div>

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -11,12 +11,9 @@ export default async function HomePage() {
         place landing component here and remove background colour
       </div>
 
-      <div className="flex flex-col items-center w-full">
+      <div className="flex flex-col items-center w-full p-12">
         <WhoAreWe />
       </div>
-
-      <div className="w-full bg-red-100">place component 2 here and remove background colour</div>
-
       <div className="w-full bg-[#161514]">
         <Sponsors />
       </div>


### PR DESCRIPTION
# Description
- Improves the responsiveness of the "Who Are We" component. On smaller screens:
  - Made image and arrow disappear (currently happens at md breakpoint not lg)
- Changed code to use flexbox instead of relative components to support better responsiveness

# How To Review
Look at homepage and make sure stuff mentioned above happens

# Improvements
- Didn't realise there was mobile page design from Charles. Can change to match if we want

![image](https://github.com/user-attachments/assets/3d23930a-6b22-4033-9cca-db1b862364a4)
![image](https://github.com/user-attachments/assets/4d8b2b21-e0ae-49e5-a334-e9866b91841e)
