### PR TITLE
Tooltips added, Requirement asterisk added.

### DIFF
--- a/src/app/(frontend)/signup/_components/SignupForm.tsx
+++ b/src/app/(frontend)/signup/_components/SignupForm.tsx
@@ -26,8 +26,8 @@ export default function SignupForm() {
         resolver: zodResolver(signupSchema),
         defaultValues: {
             timestamp: new Date(),
-            membershipPayment: "Stripe",
-            paymentScreenshotLink: "N/A",
+            membershipPayment: 'Stripe',
+            paymentScreenshotLink: 'N/A',
         },
     });
 
@@ -45,11 +45,11 @@ export default function SignupForm() {
 
             return result.canCreate;
         } catch (error: any) {
-            console.error("Error checking if member can be created:", error);
+            console.error('Error checking if member can be created:', error);
             alert(error.message);
             return false;
         }
-    }
+    };
 
     // This function handles the form submission (upon clicking the "Continue to Payment" button).
     // For now it just creates the member in the database. In the future, it will also handle the payment process.
@@ -57,7 +57,9 @@ export default function SignupForm() {
         // Check if the member can be created
         const canCreate = await checkCanCreate(data);
         if (!canCreate) {
-            alert("You have already signed up for the ESA membership for this year. If you think this is a mistake, please contact us.");
+            alert(
+                'You have already signed up for the ESA membership for this year. If you think this is a mistake, please contact us.',
+            );
             return;
         }
 
@@ -69,15 +71,14 @@ export default function SignupForm() {
                     'Content-Type': 'application/json',
                 },
                 body: JSON.stringify(data),
-            })
+            });
 
-            const result = await response.json()
-            console.log("Payment session result:", result)
+            const result = await response.json();
+            console.log('Payment session result:', result);
 
-            if (!response.ok) throw new Error(result.message || "Failed to start payment")
+            if (!response.ok) throw new Error(result.message || 'Failed to start payment');
 
-            window.location.href = result.url // TODO: Change this 
-        
+            window.location.href = result.url; // TODO: Change this
             reset();
         } catch (error: any) {
             alert(error.message);
@@ -100,7 +101,7 @@ export default function SignupForm() {
                             transition={{ duration: 0.3 }}
                             className="flex pl-10 md:pl-20 pr-2 md:pr-5 w-fit"
                         >
-                            <div className="py-10">
+                            <div className="flex flex-col py-10">
                                 <div className="md:flex md:justify-between gap-x-15">
                                     <FormInput
                                         label="First Name"
@@ -108,6 +109,7 @@ export default function SignupForm() {
                                         {...register('firstName')}
                                         error={errors.firstName}
                                         className="w-full placeholder:text-gray"
+                                        required={true}
                                     />
                                     <FormInput
                                         label="Last Name"
@@ -115,6 +117,7 @@ export default function SignupForm() {
                                         {...register('lastName')}
                                         error={errors.lastName}
                                         className="w-full placeholder:text-gray"
+                                        required={true}
                                     />
                                 </div>
                                 <FormInput
@@ -123,6 +126,7 @@ export default function SignupForm() {
                                     {...register('email')}
                                     error={errors.email}
                                     className="w-full placeholder:text-gray"
+                                    required={true}
                                 />
                                 <div className="md:flex md:justify-between">
                                     <FormSelect
@@ -137,22 +141,34 @@ export default function SignupForm() {
                                             { value: '4th Year+', label: '4th Year+' },
                                         ]}
                                         className="w-full"
+                                        required
                                     />
-                                    <FormInput
-                                        label="UPI (Optional)"
-                                        placeholder="Enter your UPI"
-                                        {...register('upi')}
-                                        error={errors.upi}
-                                        className="w-full placeholder:text-gray"
-                                    />
+                                    {/* Tooltip text */}
+                                    <div className="min-h-auto flex flex-col justify-between">
+                                        <FormInput
+                                            label="UPI"
+                                            placeholder="Enter your UPI"
+                                            {...register('upi')}
+                                            error={errors.upi}
+                                            className="w-full placeholder:text-gray"
+                                            showTooltip={true}
+                                            tooltip='The characters before the @ in your UoA email address or "000" if you are from AUT'
+                                        />
+                                    </div>
                                 </div>
+
                                 <FormInput
-                                    label="Membership Card Number (Optional)"
+                                    label="Membership Card Number"
                                     placeholder="Enter Card Number"
                                     {...register('membershipCardNumber')}
                                     error={errors.membershipCardNumber}
                                     className="w-full placeholder:text-gray"
+                                    showTooltip={true}
+                                    tooltip='Put "0" if it has not been given to you - we will get in touch!'
                                 />
+                                <p className="text-xs mb-5 mx-auto">
+                                    Fields marked with * are required
+                                </p>
                             </div>
 
                             <div className="flex justify-end items-center pl-2 md:pl-5">
@@ -166,7 +182,7 @@ export default function SignupForm() {
                                             'email',
                                             'yearOfStudy',
                                             'upi',
-                                            'membershipCardNumber'
+                                            'membershipCardNumber',
                                         ]);
                                         if (valid) setStep(2);
                                     }}
@@ -196,11 +212,12 @@ export default function SignupForm() {
                             <div className="flex flex-col justify-center py-10">
                                 <div className="md:flex md:justify-between gap-x-15">
                                     <FormInput
-                                        label="Ethnicity (E.g. Chinese"
+                                        label="Ethnicity (E.g. Chinese)"
                                         placeholder="Enter Here"
                                         {...register('ethnicity')}
                                         error={errors.ethnicity}
                                         className="w-full placeholder:text-gray"
+                                        required={true}
                                     />
                                     <FormSelect
                                         label="Gender"
@@ -217,30 +234,34 @@ export default function SignupForm() {
                                             { value: 'other', label: 'Other' },
                                         ]}
                                         className="w-full"
+                                        required={true}
                                     />
                                 </div>
                                 <FormInput
-                                    label="Which ESA Committee Member convinced you to sign-up? (Optional)"
-                                    placeholder="Enter the name of ESA committee member that convinced you to sign-up (optional)"
+                                    label="Which ESA Committee Member convinced you to sign-up?"
+                                    placeholder="Enter Full Name"
                                     {...register('convincedByCommitteeMember')}
                                     error={errors.convincedByCommitteeMember}
                                     className="w-full placeholder:text-gray"
                                 />
                                 <FormInput
-                                    label="Person who referred you (Optional)"
-                                    placeholder="Enter Full Name Here"
+                                    label="Person who referred you"
+                                    placeholder="Enter Full Name"
                                     {...register('referrerName')}
                                     error={errors.referrerName}
                                     className="w-full placeholder:text-gray"
                                 />
                                 <FormTextarea
-                                    label="Notes (Optional)"
+                                    label="Notes"
                                     placeholder="Enter Notes Here"
                                     {...register('notes')}
                                     error={errors.notes}
                                     className="w-full placeholder:text-gray"
                                     rows={1}
                                 />
+                                <p className="text-xs mb-5 mx-auto">
+                                    Fields marked with * are required
+                                </p>
                                 <Button
                                     type="submit"
                                     className="w-fit mx-auto flex items-center gap-x-2 select-none z-10"

--- a/src/app/(frontend)/signup/_components/SignupForm.tsx
+++ b/src/app/(frontend)/signup/_components/SignupForm.tsx
@@ -141,20 +141,17 @@ export default function SignupForm() {
                                             { value: '4th Year+', label: '4th Year+' },
                                         ]}
                                         className="w-full"
-                                        required
+                                        required={true}
                                     />
-                                    {/* Tooltip text */}
-                                    <div className="min-h-auto flex flex-col justify-between">
-                                        <FormInput
-                                            label="UPI"
-                                            placeholder="Enter your UPI"
-                                            {...register('upi')}
-                                            error={errors.upi}
-                                            className="w-full placeholder:text-gray"
-                                            showTooltip={true}
-                                            tooltip='The characters before the @ in your UoA email address or "000" if you are from AUT'
-                                        />
-                                    </div>
+                                    <FormInput
+                                        label="UPI"
+                                        placeholder="Enter your UPI"
+                                        {...register('upi')}
+                                        error={errors.upi}
+                                        className="w-full placeholder:text-gray"
+                                        showTooltip={true}
+                                        tooltip='The characters before the @ in your UoA email address or "000" if you are from AUT'
+                                    />
                                 </div>
 
                                 <FormInput

--- a/src/app/(frontend)/signup/_components/SignupForm.tsx
+++ b/src/app/(frontend)/signup/_components/SignupForm.tsx
@@ -163,9 +163,6 @@ export default function SignupForm() {
                                     showTooltip={true}
                                     tooltip='Put "0" if it has not been given to you - we will get in touch!'
                                 />
-                                <p className="text-xs mb-5 mx-auto">
-                                    Fields marked with * are required
-                                </p>
                             </div>
 
                             <div className="flex justify-end items-center pl-2 md:pl-5">
@@ -256,9 +253,6 @@ export default function SignupForm() {
                                     className="w-full placeholder:text-gray"
                                     rows={1}
                                 />
-                                <p className="text-xs mb-5 mx-auto">
-                                    Fields marked with * are required
-                                </p>
                                 <Button
                                     type="submit"
                                     className="w-fit mx-auto flex items-center gap-x-2 select-none z-10"

--- a/src/app/(frontend)/test/page.tsx
+++ b/src/app/(frontend)/test/page.tsx
@@ -1,37 +1,37 @@
-import {Button} from "@/components/ui/Button";
+import { Button } from '@/components/ui/Button';
 
 const test = () => {
-  return (
-      <div className="bg-[#161514] p-8 text-primary-white">
-          <h1>Heading 1</h1>
-          <h2>Heading 2</h2>
-          <h3>Heading 3</h3>
-          <p>Paragraph</p>
+    return (
+        <div className="bg-[#161514] p-8 text-primary-white">
+            <h1>Heading 1</h1>
+            <h2>Heading 2</h2>
+            <h3>Heading 3</h3>
+            <p>Paragraph</p>
 
-          <p className="text-primary-white mt-5">Text Primary White</p>
-          <p className="text-primary-grey bg-primary-white">Text Primary Grey</p>
-          <p className="text-primary-blue bg-primary-white">Text Primary Blue</p>
-          <p className="text-accent">Text Accent</p>
-          <p className="text-accent-light">Text Accent Light</p>
-          <p className="text-accent-dark">Text Accent Dark</p>
-          <p className="text-primary-red">Text Primary Red</p>
+            <p className="text-primary-white mt-5">Text Primary White</p>
+            <p className="text-primary-grey bg-primary-white">Text Primary Grey</p>
+            <p className="text-primary-blue bg-primary-white">Text Primary Blue</p>
+            <p className="text-accent">Text Accent</p>
+            <p className="text-accent-light">Text Accent Light</p>
+            <p className="text-accent-dark">Text Accent Dark</p>
+            <p className="text-primary-red">Text Primary Red</p>
 
-          <div className="flex flex-col lg:flex-row gap-5 mt-5">
-              <p className="text-primary-white lg:text-primary-red">Media Query</p>
-              <p className="text-primary-white lg:text-primary-red">Media Query</p>
-              <p className="text-primary-white lg:text-primary-red">Media Query</p>
-          </div>
+            <div className="flex flex-col lg:flex-row gap-5 mt-5">
+                <p className="text-primary-white lg:text-primary-red">Media Query</p>
+                <p className="text-primary-white lg:text-primary-red">Media Query</p>
+                <p className="text-primary-white lg:text-primary-red">Media Query</p>
+            </div>
 
-          <div className="flex flex-col lg:flex-row gap-5 mt-5">
-              <Button>This is a test Button</Button>
-              <Button href="/">This is a button with a link</Button>
-          </div>
+            <div className="flex flex-col lg:flex-row gap-5 mt-5">
+                <Button>This is a test Button</Button>
+                <Button href="/">This is a button with a link</Button>
+            </div>
 
-          <div className="mt-5">
-              <p>if you want to test any components, you can place them here</p>
-          </div>
-      </div>
-  )
-}
+            <div className="mt-5">
+                <p>if you want to test any components, you can place them here</p>
+            </div>
+        </div>
+    );
+};
 
-export default test
+export default test;

--- a/src/components/ui/FormInput.tsx
+++ b/src/components/ui/FormInput.tsx
@@ -1,39 +1,70 @@
-import { InputHTMLAttributes, forwardRef } from "react";
-import { FieldError } from "react-hook-form";
-import {cn} from "@/lib/utils";
+import { InputHTMLAttributes, forwardRef } from 'react';
+import { FieldError } from 'react-hook-form';
+import { cn } from '@/lib/utils';
+import { useState } from 'react';
 
 interface FormInputProps extends InputHTMLAttributes<HTMLInputElement> {
     label?: string;
     placeholder: string;
     error?: FieldError;
     className?: string;
+    tooltip?: string;
+    showTooltip?: boolean;
+    required?: boolean;
 }
 
 const FormInput = forwardRef<HTMLInputElement, FormInputProps>(
-    ({ label, placeholder, error, className, ...rest }, ref) => {
+    ({ label, placeholder, error, className, tooltip, showTooltip, required, ...rest }, ref) => {
+        const [isHovered, setIsHovered] = useState(false);
         return (
-            <div className="mb-2">
-                <label className="block mb-1 font-medium px-3">
-                    {label}
-                </label>
+            <div className="mb-8">
+                {/* Parent flex row for Label and Tooltip */}
+                <div className="flex items-center pl-3 mb-1">
+                    {/* Label Element with Error Asterisk */}
+                    <div className="flex">
+                        <label className="block font-medium">{label}</label>
+                        <p
+                            className={cn(
+                                'text-sm inline-block transition-all duration-50 h-5',
+                                error ? 'text-red-500 visible' : required ? 'visible' : 'invisible',
+                            )}
+                        >
+                            *
+                        </p>
+                    </div>
+
+                    {/* Tooltip Element and logic */}
+                    {showTooltip && (
+                        <div
+                            className="ml-auto relative text-xs"
+                            onMouseEnter={() => setIsHovered(true)}
+                            onMouseLeave={() => setIsHovered(false)}
+                        >
+                            <div className="bg-slate-800 rounded-full w-4 h-4 flex justify-center cursor-pointer ">
+                                ?
+                            </div>
+                            {isHovered && tooltip && (
+                                <div className="absolute right-0 bottom-5 inline-block max-w-[40vw] w-max bg-black px-2 py-1 rounded z-10">
+                                    {tooltip}
+                                </div>
+                            )}
+                        </div>
+                    )}
+                </div>
+                {/* Input Field Element*/}
                 <input
                     ref={ref}
                     placeholder={placeholder}
-                    className={cn(`border border-white rounded-2xl p-1 px-3 placeholder:text-white`, className)}
+                    className={cn(
+                        `border border-white rounded-2xl p-1 px-3 placeholder:text-white`,
+                        className,
+                    )}
                     {...rest}
                 />
-                <p
-                    className={cn(
-                        "text-sm px-3 transition-all duration-200 h-5",
-                        error ? "text-red-500 visible" : "invisible"
-                    )}
-                    >
-                    {error?.message}
-                </p>
             </div>
         );
-    }
+    },
 );
 
-FormInput.displayName = "FormInput";
+FormInput.displayName = 'FormInput';
 export default FormInput;

--- a/src/components/ui/FormInput.tsx
+++ b/src/components/ui/FormInput.tsx
@@ -17,7 +17,7 @@ const FormInput = forwardRef<HTMLInputElement, FormInputProps>(
     ({ label, placeholder, error, className, tooltip, showTooltip, required, ...rest }, ref) => {
         const [isHovered, setIsHovered] = useState(false);
         return (
-            <div className="mb-8">
+            <div className="mb-2">
                 {/* Parent flex row for Label and Tooltip */}
                 <div className="flex items-center pl-3 mb-1">
                     {/* Label Element with Error Asterisk */}
@@ -61,6 +61,15 @@ const FormInput = forwardRef<HTMLInputElement, FormInputProps>(
                     )}
                     {...rest}
                 />
+
+                <p
+                    className={cn(
+                        'text-sm px-3 transition-all duration-200 h-5',
+                        error ? 'text-red-500 visible' : 'invisible',
+                    )}
+                >
+                    {error?.message}
+                </p>
             </div>
         );
     },

--- a/src/components/ui/FormSelect.tsx
+++ b/src/components/ui/FormSelect.tsx
@@ -1,6 +1,7 @@
 import { SelectHTMLAttributes, forwardRef } from 'react';
 import { FieldError } from 'react-hook-form';
 import { cn } from '@/lib/utils';
+import { useState } from 'react';
 
 interface FormSelectProps extends Omit<SelectHTMLAttributes<HTMLSelectElement>, 'children'> {
     className?: string;
@@ -9,13 +10,53 @@ interface FormSelectProps extends Omit<SelectHTMLAttributes<HTMLSelectElement>, 
     error?: FieldError;
     options: Array<{ value: string; label: string }>;
     placeholder?: string;
+    showTooltip?: boolean;
+    tooltip?: string;
+    required?: boolean;
 }
 
 const FormSelect = forwardRef<HTMLSelectElement, FormSelectProps>(
-    ({ className, label, error, options, placeholder, ...rest }, ref) => {
+    (
+        { className, label, error, options, placeholder, showTooltip, tooltip, required, ...rest },
+        ref,
+    ) => {
+        const [isHovered, setIsHovered] = useState(false);
         return (
-            <div className="mb-4">
-                <label className="block mb-1 font-medium px-3">{label}</label>
+            <div className="mb-8">
+                {/* Parent flex row for Label and Tooltip */}
+                <div className="flex items-center pl-3 mb-1">
+                    {/* Label Element with Error Asterisk */}
+                    <div className="flex">
+                        <label className="block font-medium">{label}</label>
+                        <p
+                            className={cn(
+                                'text-sm inline-block transition-all duration-50 h-5',
+                                error ? 'text-red-500 visible' : required ? 'visible' : 'invisible',
+                            )}
+                        >
+                            *
+                        </p>
+                    </div>
+
+                    {/* Tooltip Element and logic */}
+                    {showTooltip && (
+                        <div
+                            className="ml-auto relative text-xs"
+                            onMouseEnter={() => setIsHovered(true)}
+                            onMouseLeave={() => setIsHovered(false)}
+                        >
+                            <div className="bg-slate-800 rounded-full w-4 h-4 flex justify-center cursor-pointer ">
+                                ?
+                            </div>
+                            {isHovered && tooltip && (
+                                <div className="absolute right-0 bottom-5 inline-block max-w-[40vw] w-max bg-black px-2 py-1 rounded z-10">
+                                    {tooltip}
+                                </div>
+                            )}
+                        </div>
+                    )}
+                </div>
+                {/* Select Field Element */}
                 <select
                     ref={ref}
                     defaultValue={placeholder ? '' : undefined}
@@ -30,21 +71,12 @@ const FormSelect = forwardRef<HTMLSelectElement, FormSelectProps>(
                             {placeholder}
                         </option>
                     )}
-
                     {options.map((option) => (
                         <option key={option.value} value={option.value} className="text-black">
                             {option.label}
                         </option>
                     ))}
                 </select>
-                <p
-                    className={cn(
-                        "text-sm px-3 transition-all duration-200 h-5",
-                        error ? "text-red-500 visible" : "invisible"
-                    )}
-                    >
-                    {error?.message || "Error placeholder"}
-                </p>
             </div>
         );
     },

--- a/src/components/ui/FormSelect.tsx
+++ b/src/components/ui/FormSelect.tsx
@@ -22,7 +22,7 @@ const FormSelect = forwardRef<HTMLSelectElement, FormSelectProps>(
     ) => {
         const [isHovered, setIsHovered] = useState(false);
         return (
-            <div className="mb-8">
+            <div className="mb-2">
                 {/* Parent flex row for Label and Tooltip */}
                 <div className="flex items-center pl-3 mb-1">
                     {/* Label Element with Error Asterisk */}
@@ -77,6 +77,14 @@ const FormSelect = forwardRef<HTMLSelectElement, FormSelectProps>(
                         </option>
                     ))}
                 </select>
+                <p
+                    className={cn(
+                        'text-sm px-3 transition-all duration-200 h-5',
+                        error ? 'text-red-500 visible' : 'invisible',
+                    )}
+                >
+                    {error?.message}
+                </p>
             </div>
         );
     },


### PR DESCRIPTION
# Description

In this PR I have made some changes to the **FormSelect** and **FormInput** components, both of which have been modified Identically:
## key points
- I have removed the error message that appeared at the bottom when the supplied value did not meet the success criteria.
- I have added the tooltip feature that allows for 2 more parameters, "showTooltip" and "tooltip". 
- I have added the "required" parameter that adds a white * to the end of the label to mark the input field below as required. If the user triggers an error this asterisk turns red.
- I have added a message at the bottom of the form to increase UX by telling users that * refers to a required field entry. Some people not familiar may not understand * immediately. To accommodate for this new element I have made the immediate child div of motion.div a flex-col to centre the message at the bottom.
- I have removed the (Optional) text from each "optional" input field as required by the project task.
- I have added comments to the previous code of FormInput and FormSelect to increase readability.
- I have increased the bottom margin tailwind class of the FormInput and FormSelect in the parent div to increase. This increase in margin is primary due to the removal of the Error message at the bottom, although it was invisible it was still technically rendered by the browser and thus contributed to the "gap" present between each input field. It was increased from mb-2 to mb-8.

## Added parameters for FormInput and FormSelect
<table>
<tr>
<th></th>
<th>showTooltip</th>
<th>tooltip</th>
<th>required</th>
</tr>
<tr>
<td>Type:</td>
<td>Boolean</td>
<td>String</td>
<td>Boolean</td>
</tr>
<tr>
<td>Functionality</td>
<td>Shows/Hides tooltip Question Mark</td>
<td>Message to display when user hovers Question Mark</td>
<td>Adds * to label and uses error logic to determine its colour</td>
</tr>
<tr>
<td>Example</td>
<td>showTooltip = {true}</td>
<td>tooltip = "This is a tooltip"</td>
<td>required = {true}</td>
</tr>
</table>

By default, if the parameter is not given then it is assumed false by the program

## Notes
Off the top of my head this is everything. It should still be fine in mobile. Under my current understanding modern browsers will handle the "hover" action as a tap toggle on touchscreen / mobile devices. This behaviour is correct as tested with dev tools. Again idk what's happening with the test component. It just decided everything was a modification, I think prettier freaked out and git recorded that as a modification. Nothing has been modified in the test component except format by prettier. You can see that in the modifications below.

