### PR TITLE
ExecPage, ExecCategory, ExecCard

### DIFF
--- a/src/app/(frontend)/execs/_components/ExecCard.tsx
+++ b/src/app/(frontend)/execs/_components/ExecCard.tsx
@@ -1,10 +1,9 @@
-// components/ExecCard.tsx
 import Image from 'next/image';
 import { Exec } from '../page';
 
 type ExecCardProps = {
     exec: Exec;
-    tiltLeft: boolean; // keeps your original API
+    tiltLeft: boolean;
 };
 
 export default function ExecCard({ exec, tiltLeft }: ExecCardProps) {

--- a/src/app/(frontend)/execs/_components/ExecCard.tsx
+++ b/src/app/(frontend)/execs/_components/ExecCard.tsx
@@ -1,0 +1,45 @@
+// components/ExecCard.tsx
+import Image from 'next/image';
+import { Exec } from '../page';
+
+type ExecCardProps = {
+    exec: Exec;
+    tiltLeft: boolean; // keeps your original API
+};
+
+export default function ExecCard({ exec, tiltLeft }: ExecCardProps) {
+    const { name, role, about } = exec;
+    const tiltDeg = tiltLeft ? '-3deg' : '3deg';
+
+    return (
+        <article className="flex flex-col items-center mx-auto">
+            <div className="relative inline-block overflow-visible">
+                <div
+                    className="relative bg-white rounded-2xl p-2 z-10"
+                    style={{ transform: `rotate(${tiltDeg})` }}
+                >
+                    {/* Image */}
+                    <div className="w-[90%] mx-auto mt-[5%] bg-primary-white aspect-square">
+                        <Image
+                            src={exec.imageUrl}
+                            alt={`${name} portrait`}
+                            width={256}
+                            height={256}
+                            className="w-full h-full object-cover"
+                        />
+                    </div>
+
+                    {/* Name & role */}
+                    <div className="px-3 py-2 text-black">
+                        <p className="font-bold">{name}</p>
+                        <p className="text-xs">{role}</p>
+                    </div>
+                </div>
+                <div className="absolute inset-0 rounded-2xl ring-1 ring-gray-200 pointer-events-none" />
+            </div>
+
+            {/* Optional bio */}
+            <p className="hidden md:inline text-xs text-center mt-5">{about}</p>
+        </article>
+    );
+}

--- a/src/app/(frontend)/execs/_components/ExecCategory.tsx
+++ b/src/app/(frontend)/execs/_components/ExecCategory.tsx
@@ -9,9 +9,6 @@ type ExecCategoryProps = {
 };
 
 export default function ExecCategory({ title, blurb, execs }: ExecCategoryProps) {
-    const lastIndex = execs.length - 1;
-    const isOdd = execs.length % 2 === 1;
-
     return (
         <div className="flex flex-col py-8 px-10 items-center">
             <div className="relative mx-auto text-center mb-6 inline-flex flex-col items-center">
@@ -23,23 +20,15 @@ export default function ExecCategory({ title, blurb, execs }: ExecCategoryProps)
                 </p>
             </div>
 
-            {/* Card grid / flex container */}
-            <div className="mt-3 grid grid-cols-2 gap-y-10 gap-x-10 sm:gap-y-10 sm:gap-x-20 lg:gap-x-30">
-                {execs.map((exec, i) => {
-                    const shouldCenter = isOdd && i === lastIndex;
-                    return (
-                        /* identifies last card in the category and centers it while mantaining the same size as other cards */
-                        <div
-                            key={exec.id}
-                            className={
-                                `${shouldCenter ? 'col-span-2 flex justify-center mx-auto' : ''}` +
-                                ' max-w-45 sm:max-w-auto'
-                            }
-                        >
-                            <ExecCard exec={exec} tiltLeft={exec.tilt} />
-                        </div>
-                    );
-                })}
+            <div className="mt-3 flex flex-wrap justify-center gap-y-10 gap-x-10 lg:gap-x-15 max-w-2xl [@media(min-width:1920px)]:max-w-5xl">
+                {execs.map((exec) => (
+                    <div
+                        key={exec.id}
+                        className="max-w-45 sm:max-w-auto"
+                    >
+                        <ExecCard exec={exec} tiltLeft={exec.tilt} />
+                    </div>
+                ))}
             </div>
         </div>
     );

--- a/src/app/(frontend)/execs/_components/ExecCategory.tsx
+++ b/src/app/(frontend)/execs/_components/ExecCategory.tsx
@@ -22,7 +22,7 @@ export default function ExecCategory({ title, blurb, execs }: ExecCategoryProps)
             </div>
 
             {/* Card grid / flex container */}
-            <div className="mt-3 grid grid-cols-2 gap-y-10 gap-x-10 sm:gap-y-10 sm:gap-x-20 lg:gap-y-20 lg:gap-x-30">
+            <div className="mt-3 grid grid-cols-2 gap-y-10 gap-x-10 sm:gap-y-10 sm:gap-x-20 lg:gap-x-30">
                 {execs.map((exec, i) => {
                     const shouldCenter = isOdd && i === lastIndex;
                     return (

--- a/src/app/(frontend)/execs/_components/ExecCategory.tsx
+++ b/src/app/(frontend)/execs/_components/ExecCategory.tsx
@@ -20,7 +20,7 @@ export default function ExecCategory({ title, blurb, execs }: ExecCategoryProps)
                 </p>
             </div>
 
-            <div className="mt-3 flex flex-wrap justify-center gap-y-10 gap-x-10 lg:gap-x-15 max-w-2xl [@media(min-width:1920px)]:max-w-5xl">
+            <div className="mt-3 flex flex-wrap justify-center gap-y-10 gap-x-10 lg:gap-x-15 max-w-2xl [@media(min-width:1921px)]:max-w-5xl">
                 {execs.map((exec) => (
                     <div
                         key={exec.id}

--- a/src/app/(frontend)/execs/_components/ExecCategory.tsx
+++ b/src/app/(frontend)/execs/_components/ExecCategory.tsx
@@ -18,7 +18,9 @@ export default function ExecCategory({ title, blurb, execs }: ExecCategoryProps)
                 <p className="font-reservoir-grunge text-3xl bg-primary-red-400 px-4 pt-2 pb-1 rounded-2xl">
                     {title}
                 </p>
-                <p className="mt-3 text-sm max-w-[80%] sm:max-w-[60%] mx-auto">{blurb}</p>
+                <p className="mt-3 text-sm max-w-[80%] sm:max-w-[60%] xl:max-w-[40%] mx-auto">
+                    {blurb}
+                </p>
             </div>
 
             {/* Card grid / flex container */}

--- a/src/app/(frontend)/execs/_components/ExecCategory.tsx
+++ b/src/app/(frontend)/execs/_components/ExecCategory.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import ExecCard from './ExecCard';
+import { Exec } from '../page';
+
+type ExecCategoryProps = {
+    title?: string;
+    blurb?: string;
+    execs: Exec[];
+};
+
+export default function ExecCategory({ title, blurb, execs }: ExecCategoryProps) {
+    const lastIndex = execs.length - 1;
+    const isOdd = execs.length % 2 === 1;
+
+    return (
+        <div className="flex flex-col py-8 px-10 items-center">
+            <div className="relative mx-auto text-center mb-6 inline-flex flex-col items-center">
+                <p className="font-reservoir-grunge text-3xl bg-primary-red-400 px-4 pt-2 pb-1 rounded-2xl">
+                    {title}
+                </p>
+                <p className="mt-3 text-sm max-w-[80%] sm:max-w-[60%] mx-auto">{blurb}</p>
+            </div>
+
+            {/* Card grid / flex container */}
+            <div className="mt-3 grid grid-cols-2 gap-y-10 gap-x-10 sm:gap-y-10 sm:gap-x-20 lg:gap-y-20 lg:gap-x-30">
+                {execs.map((exec, i) => {
+                    const shouldCenter = isOdd && i === lastIndex;
+                    return (
+                        /* identifies last card in the category and centers it while mantaining the same size as other cards */
+                        <div
+                            key={exec.id}
+                            className={
+                                `${shouldCenter ? 'col-span-2 flex justify-center mx-auto' : ''}` +
+                                ' max-w-45 sm:max-w-auto'
+                            }
+                        >
+                            <ExecCard exec={exec} tiltLeft={exec.tilt} />
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}

--- a/src/app/(frontend)/execs/page.tsx
+++ b/src/app/(frontend)/execs/page.tsx
@@ -41,7 +41,7 @@ export default function Execs() {
     }, [data]);
 
     return (
-        <main className="flex flex-col items-center">
+        <main className="flex flex-col items-center px-[5%] md:px-[10%]">
             <div className="flex flex-col items-center font-bold mt-35 md:mt-25">
                 <p className="text-primary-red-400 text-4xl md:text-5xl font-reservoir-grunge ">
                     Our Execs

--- a/src/app/(frontend)/execs/page.tsx
+++ b/src/app/(frontend)/execs/page.tsx
@@ -40,7 +40,6 @@ export default function Execs() {
         };
     }, [data]);
 
-    /* render */
     return (
         <main className="flex flex-col items-center">
             <div className="flex flex-col items-center font-bold mt-35 md:mt-25">

--- a/src/app/(frontend)/execs/page.tsx
+++ b/src/app/(frontend)/execs/page.tsx
@@ -1,5 +1,71 @@
-import WipPage from '@/components/WipPage';
+'use client';
 
-export default function execs() {
-    return <WipPage />;
+import ExecCategory from './_components/ExecCategory';
+import { useExecs } from '@/features/execs/data/tanstack/useExecs';
+import { useMemo } from 'react';
+
+export interface Exec {
+    id: string;
+    name: string;
+    role: string;
+    about: string;
+    imageUrl: string;
+    tilt: boolean;
+}
+
+export default function Execs() {
+    const { data, isLoading, error } = useExecs();
+
+    const { groups } = useMemo(() => {
+        if (!data) return { groups: [] };
+
+        const roleMap: Record<string, Exec[]> = {};
+
+        for (const e of data) {
+            const exec: Exec = {
+                id: e._id,
+                name: e.name,
+                role: e.role,
+                about: e.about,
+                imageUrl: e.image,
+                tilt: Math.random() < 0.5,
+            };
+            (roleMap[exec.role] ??= []).push(exec);
+        }
+
+        return {
+            groups: Object.entries(roleMap)
+                .sort(([a], [b]) => a.localeCompare(b))
+                .map(([role, execs]) => ({ role, execs })),
+        };
+    }, [data]);
+
+    /* render */
+    return (
+        <main className="flex flex-col items-center">
+            <div className="flex flex-col items-center font-bold mt-35 md:mt-25">
+                <p className="text-primary-red-400 text-4xl md:text-5xl font-reservoir-grunge ">
+                    Our Execs
+                </p>
+                <p className="text-xs md:text-md font-medium font-roboto-mono mt-2">
+                    View our past and previous executives here!
+                </p>
+                <hr className="my-6 border-2 w-[75vw] min-w-[300px] max-w-[900px] border-primary-grey-light" />
+            </div>
+
+            {isLoading && <p>Loading execs…</p>}
+            {error && <p>Error loading execs.</p>}
+
+            {!isLoading &&
+                !error &&
+                groups.map((group) => (
+                    <ExecCategory
+                        key={group.role}
+                        title={group.role}
+                        blurb="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat" /* will need to be automated at some point in the future if each category wants its own blurb */
+                        execs={group.execs}
+                    />
+                ))}
+        </main>
+    );
 }

--- a/src/app/(frontend)/execs/page.tsx
+++ b/src/app/(frontend)/execs/page.tsx
@@ -41,7 +41,7 @@ export default function Execs() {
     }, [data]);
 
     return (
-        <main className="flex flex-col items-center px-[5%] md:px-[10%]">
+        <section className="flex flex-col items-center px-[5%] md:px-[10%]">
             <div className="flex flex-col items-center font-bold mt-35 md:mt-25">
                 <p className="text-primary-red-400 text-4xl md:text-5xl font-reservoir-grunge ">
                     Our Execs
@@ -65,6 +65,6 @@ export default function Execs() {
                         execs={group.execs}
                     />
                 ))}
-        </main>
+        </section>
     );
 }


### PR DESCRIPTION
# Details:
This PR focuses on 3 details: ExecPage, ExecCategory, ExecCard

## ExecPage or "./execs/page.tsx":
This component is the main body of the execs page, it provides the space that the ExecCategories are placed and contains logic that fetches the Exec data from tanstack using the "useExecs()"  function, which itself consequently uses the payload functions "getExecs" and "parseExecs"

It primarily focuses on modifying the data structure provided by the payload collection into a role oriented array. imagine the fetched data being:``` execData:[exec1:[name, role, image, about], exec2:[name, role, image, about], exec3:[name, role, image, about]]```, page.tsx aims to modify it to produce ```groups:['role1':[exec1, exec2, exec3], 'role2':[exec1, exec2, exec3]]``` or something rather.

Using this role oriented array it maps out the role data into ExecCategory components which are subsequently placed in the viewport.

It also contains the title, master blurb, and title break graphic.

Optimizations that were made include the use of "useMemo()" this is included in the standard react library and is a client side implementation that caches data between frame states whenever the browser feels like it wants to re-render the view port. It is useful in dynamic websites, To refresh the useMemo cache one must reload the tab or update any of the execData ( this itself does not cause the browser to re-render the changes ) | TLDR it prevents the function from running an excessive number of times.

Other optimizations include the use of the standard react Image component. 

It should be noted that:
- The blurb for each category is hardcoded, this needs to be implemented as a collection in payload or hardcoded elsewhere and imported into execs/page,tsx
- One exec record cannot have multiple roles, there must be multiple records of an exec in payload if they have multiple roles and wish to show up under multiple categories
- The categories are character sensitive which means what ever is entered into the payload collection, is what is displayed and mapped onto the execs page. EG: if there were a role named ' Co-President ' and all the Co-Presidents were under that but someone accidentally put ' Co President ' in the payload when creating a new exec record then the pages.tsx would create two distinct categories one with one record in it and one with all the other records in it, one correct and one incorrect. This should be updated for ambiguity in the future.

## ExecCategory:
This component focuses on correctly mapping out and placing ExecCards in a grid so that they are displayed correctly in a responsive viewport format. It must make sure that the last ExecCard in an uneven array of provided execs is spanned across 2 cols in the grid rather than one to make sure it appears centered. Subsequently it must also prevent that last ExecCard from being oversized as it is not "squeezed" by the viewport as much. 

## ExecCard:
This component is the part of the page that is just there to look good. It uses the exec data it was supplied with from ExecCategory to display an image sourced all the way back from payload and further (mdb?). It also displays the name and role just below the image and the about blurb just outside and below the "card" frame.

It also must use the tilt that was calculated back in page.tsx. It also creates an outline that has no angle.

