### PR TITLE
176 mobile events page

### DIFF
--- a/src/app/(frontend)/(home)/_components/Events/EventCard.tsx
+++ b/src/app/(frontend)/(home)/_components/Events/EventCard.tsx
@@ -15,12 +15,22 @@ interface EventCardProps {
     event: EventData;
     even?: boolean;
     isPast?: boolean;
+    isSeeMoreVisible?: boolean;
 }
 
-export default function EventCard({ event, even, isPast }: EventCardProps) {
+export default function EventCard({
+    event,
+    even,
+    isPast,
+    isSeeMoreVisible = true,
+}: EventCardProps) {
     const [expanded, setExpanded] = useState(false);
     const date = new Date(event.date);
     const disabled = event.locked || isPast;
+    console.log(event);
+    console.log(isPast);
+    console.log(event.locked);
+    console.log(disabled);
 
     const dateString = `${date.getDate().toString().padStart(2, '0')}.${(date.getMonth() + 1).toString().padStart(2, '0')}.${date.getFullYear().toString().slice(-2)}`;
 
@@ -171,7 +181,10 @@ export default function EventCard({ event, even, isPast }: EventCardProps) {
             {expanded && <hr className="mt-5" />}
 
             {/* Toggle button */}
-            <div className="mt-3 flex justify-end">
+            <div
+                className="mt-3 justify-end"
+                style={{ display: isSeeMoreVisible ? 'flex' : 'none' }}
+            >
                 <Button
                     variant="clear"
                     size="sm"

--- a/src/app/(frontend)/(home)/_components/Events/EventCard.tsx
+++ b/src/app/(frontend)/(home)/_components/Events/EventCard.tsx
@@ -8,6 +8,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import ArrowUp from '@/components/icons/ArrowUp';
 import EventInfo from '@/app/(frontend)/(home)/_components/Events/EventInfo';
 import SquigglyArrow from '@/components/icons/SquigglyArrow';
+import { ChevronDown, ChevronUp } from 'lucide-react';
 
 const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
@@ -188,11 +189,12 @@ export default function EventCard({
                 <Button
                     variant="clear"
                     size="sm"
-                    className="whitespace-nowrap"
+                    className="flex justify-center gap-3 px-4 py-2 whitespace-nowrap"
                     onClick={() => setExpanded(!expanded)}
                     aria-expanded={expanded}
                 >
-                    {expanded ? 'See Less' : 'See More'}
+                    {expanded ? 'See less' : 'See more'}
+                    {expanded ? <ChevronUp strokeWidth={2.5} /> : <ChevronDown strokeWidth={2.5} />}
                 </Button>
             </div>
         </div>

--- a/src/app/(frontend)/(home)/_components/Events/EventCard.tsx
+++ b/src/app/(frontend)/(home)/_components/Events/EventCard.tsx
@@ -48,7 +48,7 @@ export default function EventCard({
                             <h4 className="md:hidden">{event.title}</h4>
                             <h4 className="hidden md:block">{days[date.getDay()]}</h4>
                             <h4>{dateString}</h4>
-                            <p className="md:hidden break-all">
+                            <p className="md:hidden text-wrap">
                                 {!event.locked
                                     ? event.description
                                     : 'This is a locked upcoming event, come back another time to find out what it is! 👀'}
@@ -90,7 +90,7 @@ export default function EventCard({
                     <div className="hidden md:flex flex-col w-full gap-y-3 mt-2 md:mt-0 !bg-transparent !border-none">
                         <h4>{!event.locked ? event.title : 'Locked Event'}</h4>
                         <hr />
-                        <p className="break-all">
+                        <p className="text-wrap">
                             {!event.locked
                                 ? event.description
                                 : 'This is a locked upcoming event, come back another time to find out what it is! 👀'}

--- a/src/app/(frontend)/(home)/_components/Events/EventCard.tsx
+++ b/src/app/(frontend)/(home)/_components/Events/EventCard.tsx
@@ -28,31 +28,35 @@ export default function EventCard({
     const [expanded, setExpanded] = useState(false);
     const date = new Date(event.date);
     const disabled = event.locked || isPast;
+
     console.log(event);
-    console.log(isPast);
-    console.log(event.locked);
-    console.log(disabled);
 
     const dateString = `${date.getDate().toString().padStart(2, '0')}.${(date.getMonth() + 1).toString().padStart(2, '0')}.${date.getFullYear().toString().slice(-2)}`;
 
     return (
         <div className="w-full">
-            {expanded && <hr className="mb-5" />}
+            <hr className="md:hidden mb-5" />
             {/* Collapsed view */}
             {!expanded && (
                 <div className="w-fit md:w-full flex flex-col md:flex-row gap-x-5">
                     <div
-                        className={`flex gap-x-5 justify-center items-center ${
-                            even ? 'flex-row-reverse md:flex-row' : 'flex-row'
+                        className={`flex gap-x-5 justify-center items-start ${
+                            even ? 'flex-row ' : 'flex-row-reverse md:flex-row'
                         }`}
                     >
-                        <div className="flex flex-col">
-                            <h4>{days[date.getDay()]}</h4>
+                        <div className="flex flex-col flex-1">
+                            <h4 className="md:hidden">{event.title}</h4>
+                            <h4 className="hidden md:block">{days[date.getDay()]}</h4>
                             <h4>{dateString}</h4>
+                            <p className="md:hidden break-all">
+                                {!event.locked
+                                    ? event.description
+                                    : 'This is a locked upcoming event, come back another time to find out what it is! 👀'}
+                            </p>
                             <Button
                                 variant="clear"
                                 size="sm"
-                                className="whitespace-nowrap"
+                                className="hidden md:block whitespace-nowrap"
                                 href={disabled ? undefined : event.signUpForm}
                                 disabled={disabled}
                             >
@@ -61,7 +65,7 @@ export default function EventCard({
                         </div>
 
                         {/* Poster with fixed aspect ratio */}
-                        <div className="relative w-[200px] md:w-[246px] aspect-[178/123] overflow-hidden rounded-3xl">
+                        <div className="relative w-40 h-50 md:w-[246px] md:h-auto md:aspect-[178/123] overflow-hidden rounded-3xl">
                             <Image
                                 src={event.image}
                                 alt={event.imageAlt}
@@ -83,10 +87,10 @@ export default function EventCard({
                     </div>
 
                     {/* Transparent, no border */}
-                    <div className="flex flex-col w-full gap-y-3 mt-2 md:mt-0 !bg-transparent !border-none">
+                    <div className="hidden md:flex flex-col w-full gap-y-3 mt-2 md:mt-0 !bg-transparent !border-none">
                         <h4>{!event.locked ? event.title : 'Locked Event'}</h4>
                         <hr />
-                        <p>
+                        <p className="break-all">
                             {!event.locked
                                 ? event.description
                                 : 'This is a locked upcoming event, come back another time to find out what it is! 👀'}
@@ -162,11 +166,13 @@ export default function EventCard({
 
                                 {/* Button stuck bottom right */}
                                 <div className="my-6 md:my-0 md:mt-auto flex justify-end items-end">
-                                    <div className="rotate-15 hidden md:block">
-                                        <SquigglyArrow />
-                                    </div>
+                                    {disabled ? null : (
+                                        <div className="rotate-20 hidden md:block">
+                                            <SquigglyArrow amplitude={5} speed={0.05} />
+                                        </div>
+                                    )}
                                     <Button
-                                        disabled={event.locked}
+                                        disabled={disabled}
                                         className="flex flex-row items-center gap-x-2 h-fit"
                                     >
                                         Sign Up
@@ -183,7 +189,7 @@ export default function EventCard({
 
             {/* Toggle button */}
             <div
-                className="mt-3 justify-end"
+                className={`mt-3 md:justify-end ${even ? 'justify-end' : 'justify-start'} flex`}
                 style={{ display: isSeeMoreVisible ? 'flex' : 'none' }}
             >
                 <Button

--- a/src/app/(frontend)/(home)/_components/Events/Events.tsx
+++ b/src/app/(frontend)/(home)/_components/Events/Events.tsx
@@ -3,9 +3,9 @@
 import { useState } from 'react';
 import EventCard from './EventCard';
 import { EventData } from '@/types/EventData';
-import Title from "@/components/ui/Title";
-import Image from "next/image";
-import {useEvents} from "@/features/events/data/tanstack/useEvents";
+import Title from '@/components/ui/Title';
+import Image from 'next/image';
+import { useEvents } from '@/features/events/data/tanstack/useEvents';
 import { setupEvents } from '@/features/events/utils/setupEvents';
 
 export default function Events() {
@@ -17,7 +17,7 @@ export default function Events() {
     const upcomingEvents: EventData[] = [];
     const pastEvents: EventData[] = [];
 
-  setupEvents(parsedEvents, upcomingEvents, pastEvents);
+    setupEvents(parsedEvents, upcomingEvents, pastEvents);
 
     return (
         <section className="relative px-6 md:px-[8%] text-white pb-32 overflow-hidden">
@@ -41,7 +41,9 @@ export default function Events() {
             {/* latest header */}
             <div className="flex flex-col relative z-20 items-center md:items-start">
                 <Title className="mb-10">LATEST</Title>
-                {pastEvents[0] && <EventCard event={pastEvents[0]} isPast={true} />}
+                {pastEvents[0] && (
+                    <EventCard event={pastEvents[0]} isPast={true} isSeeMoreVisible={false} />
+                )}
             </div>
 
             <Image
@@ -58,7 +60,12 @@ export default function Events() {
                 <div className="flex flex-col items-center space-y-10 w-full">
                     {(showAllUpcoming ? upcomingEvents : upcomingEvents.slice(0, 2)).map(
                         (event, index) => (
-                            <EventCard key={event._id} event={event} even={index % 2 === 0} />
+                            <EventCard
+                                key={event._id}
+                                event={event}
+                                even={index % 2 === 0}
+                                isSeeMoreVisible={false}
+                            />
                         ),
                     )}
                 </div>

--- a/src/app/(frontend)/events/page.tsx
+++ b/src/app/(frontend)/events/page.tsx
@@ -42,7 +42,12 @@ export default function Events() {
                 <Title className="mb-10">LATEST</Title>
                 <div className="flex flex-col items-center space-y-10 w-full">
                     {pastEvents.slice(0, 2).map((event, index) => (
-                        <EventCard key={event._id} event={event} even={index % 2 === 0} />
+                        <EventCard
+                            key={event._id}
+                            event={event}
+                            even={index % 2 === 0}
+                            isPast={true}
+                        />
                     ))}
                 </div>
             </div>

--- a/src/app/(frontend)/events/page.tsx
+++ b/src/app/(frontend)/events/page.tsx
@@ -27,8 +27,6 @@ export default function Events() {
                 <p className="text-primary-white mb-2">View our next and previous events here!</p>
             </div>
 
-            <hr className="mx-auto mt-4 w-[1200px] h-px border-0 bg-white/50" />
-
             <div className="mt-25 flex flex-col relative z-20 items-center md:items-start">
                 <Title className="mb-10">UPCOMING</Title>
                 <div className="flex flex-col items-center space-y-10 w-full">

--- a/src/components/icons/SquigglyArrow.tsx
+++ b/src/components/icons/SquigglyArrow.tsx
@@ -1,5 +1,5 @@
-"use client"
-import React, { useEffect, useState } from "react";
+'use client';
+import React, { useEffect, useState } from 'react';
 
 interface SquigglyArrowProps {
     width?: number;
@@ -11,6 +11,7 @@ interface SquigglyArrowProps {
     strokeColor?: string;
     strokeWidth?: number;
     fillColor?: string;
+    speed?: number;
 }
 
 export default function SquigglyArrow({
@@ -20,19 +21,20 @@ export default function SquigglyArrow({
     frequency = 0.1,
     arrowLength = 20,
     arrowWidth = 10,
-    strokeColor = "#FFFFFF",
+    strokeColor = '#FFFFFF',
     strokeWidth = 5,
-    fillColor = "#FFFFFF",
+    fillColor = '#FFFFFF',
+    speed = 0.08,
 }: SquigglyArrowProps) {
     const [phase, setPhase] = useState(0);
 
     useEffect(() => {
         const id = requestAnimationFrame(function animate() {
-            setPhase(prev => prev + 0.08);
+            setPhase((prev) => prev + speed);
             requestAnimationFrame(animate);
         });
         return () => cancelAnimationFrame(id);
-    }, []);
+    }, [speed]);
 
     // calculate wave path
     const points: string[] = [];
@@ -40,7 +42,7 @@ export default function SquigglyArrow({
         const y = amplitude * Math.sin(frequency * x + phase) + height / 2;
         points.push(`${x},${y}`);
     }
-    const pathData = "M" + points.join(" L"); // M: move to, L: line to
+    const pathData = 'M' + points.join(' L'); // M: move to, L: line to
 
     // calculate position of arrowhead (attach at the end of tail path)
     const endX = width - (arrowLength - 16); // end of wave path
@@ -58,8 +60,8 @@ export default function SquigglyArrow({
         [endX + arrowWidth * Math.sin(angle), endY - arrowWidth * Math.cos(angle)],
         [endX - arrowWidth * Math.sin(angle), endY + arrowWidth * Math.cos(angle)],
     ]
-        .map(p => p.join(","))
-        .join(" ");
+        .map((p) => p.join(','))
+        .join(' ');
 
     return (
         <svg width={width + arrowLength} height={height}>


### PR DESCRIPTION
- Implemented mobile view for unexpanded events page following Figma design
- Added down arrow for see more and up arrow for see less
- Added _isSeeMoreVisible_ to EventCard component props which defaults to true if not provided and handles visibility of the see more button
- Reduced amplitude of squiggly arrow as well as adding a speed prop
  - Slightly increased the angle of the arrow
  - Speed prop doesn't really work if you edit in code and don't refresh but this shouldn't be a problem for users
- Squiggly arrow now only shows for unlocked events

Bug note?: BG image for a no image event not a very nice placeholder image and I'm not sure where it's being set from but probably some payload thing

Reminder for myself: Delete created event after merge