### PR TITLE
fix: destroy Packery instance on unmount to stop memory leak in SponsorBubbles

### DIFF
--- a/src/app/(frontend)/(home)/_components/SponsorBubbles.tsx
+++ b/src/app/(frontend)/(home)/_components/SponsorBubbles.tsx
@@ -12,6 +12,7 @@ export interface SponsorProps {
 
 export default function SponsorBubbles({ sponsors }: SponsorProps) {
     const containerRef = useRef<HTMLDivElement>(null);
+    const packeryRef = useRef<any>(null);
     const [baseSize, setBaseSize] = useState(60);
     // State to track which sponsor is hovered for tooltip display
     const [hoveredSponsor, setHoveredSponsor] = useState<{
@@ -21,17 +22,13 @@ export default function SponsorBubbles({ sponsors }: SponsorProps) {
     } | null>(null);
 
     useEffect(() => {
-        // Hide tooltip on scroll
         const handleScroll = () => {
-            if (hoveredSponsor) {
-                setHoveredSponsor(null);
-            }
+            setHoveredSponsor((current) => (current ? null : current));
         };
 
-        // Cleanup function to remove event listener
         window.addEventListener('scroll', handleScroll, true);
         return () => window.removeEventListener('scroll', handleScroll, true);
-    }, [hoveredSponsor]);
+    }, []);
 
     useEffect(() => {
         function handleResize() {
@@ -49,23 +46,30 @@ export default function SponsorBubbles({ sponsors }: SponsorProps) {
 
     useEffect(() => {
         // Import Packery client side as needs client functionality. As any as idk how to deal with TypeScript error as Packery wasn't made for TypeScript
+        let cancelled = false;
+
         import('packery' as any)
             .then((PackeryModule) => {
+                if (cancelled || !containerRef.current) return;
                 const Packery = PackeryModule.default;
-
-                if (containerRef.current) {
-                    // Initialize Packery (Used for packing in the circles together)
-                    new Packery(containerRef.current, {
-                        itemSelector: '.grid-item', // Class name for items
-                        stamp: '.stamp',
-                        gutter: 20, // Space between items
-                        horizontal: true, // Enable horizontal layout
-                    });
-                }
+                packeryRef.current = new Packery(containerRef.current, {
+                    itemSelector: '.grid-item',
+                    stamp: '.stamp',
+                    gutter: 20,
+                    horizontal: true,
+                });
             })
             .catch((error) => {
                 console.error('Failed to load Packery:', error);
             });
+
+        return () => {
+            cancelled = true;
+            if (packeryRef.current) {
+                packeryRef.current.destroy();
+                packeryRef.current = null;
+            }
+        };
     }, [baseSize]);
 
     return (


### PR DESCRIPTION
from claude:

## Summary                                                

  Fixes a memory leak on the home page caused by `SponsorBubbles` creating a new                                                                                                                              
  Packery layout instance on every mount and on every `baseSize` change without
  ever destroying the previous one. Each navigation back to `/` left behind a                                                                                                                                 
  full Packery instance plus all its DOM references, which Chrome's heap profiler                                                                                                                             
  showed as a steadily growing pile of detached nodes and `PackeryItem` objects.                                                                                                                              
                                                                                                                                                                                                              
  ## Root cause                                                                                                                                                                                               
                                                                                                                                                                                                              
  In `src/app/(frontend)/(home)/_components/SponsorBubbles.tsx`, the Packery                                                                                                                                  
  effect was calling `new Packery(...)` and discarding the return value:
                                                                                                                                                                                                              
```ts
new Packery(containerRef.current, { ... });
```                                                                                                                                                 
                                                                                                                                                                                                              
Packery attaches listeners to the container and holds references to every                                                                                                                                   
matched grid item. Without a handle to the instance, there was no way to call                                                                                                                               
.destroy(), so each remount stacked another live instance on top of the                                                                                                                                     
previous one.                                                                                                                                                                                               
                                                                                                                                                                                                            
A secondary issue: the scroll-listener effect listed hoveredSponsor in its                                                                                                                                  
dependency array, so the listener was being torn down and re-attached on every
hover change.                                                                                                                                                                                               
                                                          
**Changes** 

- Store the Packery instance in a useRef and call .destroy() in the effect                                                                                                                                  
cleanup (runs on unmount and before re-init when baseSize changes).
- Add a cancelled flag so a late-resolving dynamic import('packery') does                                                                                                                                   
not construct an orphaned instance after unmount.                                                                                                                                                           
- Switch the scroll handler to a functional setHoveredSponsor update and drop 
hoveredSponsor from the effect deps so the listener attaches once. 